### PR TITLE
Phoenix channel server doesn't heartbeat anymore, upgrade to Go 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi2-golang:1.5-slim
+FROM resin/raspberrypi2-golang:1.6-slim
 
 COPY . /go/src/github.com/opendoor-labs/gong
 CMD modprobe i2c-dev && \


### PR DESCRIPTION
At some point the phoenix channels server stopped sending heartbeats. That's only done from the clients now (though the server sends ACKs of those).

I also took this opportunity to upgrade us to the Go 1.6 base docker image.
